### PR TITLE
Use debug flag to log events to the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ It even outperforms next.js's static generated page (`getStaticProps`) with 2~2.
 
 Check the underlying [`hybrid-disk-cache`](https://github.com/rjyo/next-boost)'s performance here.
 
+## Logging
+
+Logging is enabled by default. If you use `next-boost` programmatically, you can disable logs by passing the `debug` boolean flag as an option to `CachedHandler`.
+
+
+```javascript
+...
+const cached = await CachedHandler({ script, args, debug: false });
+...
+```
+
 ## Limitations
 
 - For architecture with multiple load-balanced rendering servers, the benefit of using `next-boost` is limited. Until the url is hit on every backend server, it can still miss the cache. Though sharing the cache on network file systems with servers might help.

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -1,16 +1,16 @@
 import Cache from 'hybrid-disk-cache'
-import { log } from './utils'
+import { Logger } from './logger'
 
 let interval: NodeJS.Timeout
 
-export function initPurgeTimer(cache: Cache): void {
+export function initPurgeTimer(cache: Cache, logger: Logger): void {
   if (interval) return
   const tbd = Math.min(cache.tbd, 3600)
-  console.log('  Cache manager inited, will start to purge in %ds', tbd)
+  logger.logMessage('  Cache manager inited, will start to purge in %ds', tbd)
   interval = setInterval(() => {
     const start = process.hrtime()
     const rv = cache.purge()
-    log(start, 'purge', `purged all ${rv} inactive record(s)`)
+    logger.logOperation(start, 'purge', `purged all ${rv} inactive record(s)`)
   }, tbd * 1000)
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,40 @@
+type LoggerOptions = { debug?: boolean }
+
+export type Logger = {
+  logMessage: (...any) => void
+  logOperation: (start: [number, number], status: string, msg?: string) => void
+}
+
+export function createLogger(opts?: LoggerOptions): Logger {
+  if (opts?.debug) {
+    return DebugLogger()
+  }
+  return EmptyLogger()
+}
+
+function EmptyLogger() {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    logMessage: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    logOperation: () => {},
+  }
+}
+
+function DebugLogger() {
+  return {
+    logMessage: console.log,
+    logOperation: (
+      start: [number, number],
+      status: string,
+      msg?: string
+    ): void => {
+      const [secs, ns] = process.hrtime(start)
+      const ms = ns / 1000000
+      const timeS = `${secs > 0 ? secs + 's' : ''}`
+      const timeMs = `${secs === 0 ? ms.toFixed(1) : ms.toFixed(0)}ms`
+      const time = timeS + (secs > 1 ? '' : timeMs)
+      console.log('%s | %s: %s', time.padStart(7), status.padEnd(6), msg)
+    },
+  }
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -22,7 +22,7 @@ export type RenderResult = {
 
 let server: http.Server
 
-export type InitArgs = { script: string; args?: any }
+export type InitArgs = { script: string; args?: any; debug?: boolean }
 
 const init = createHandler('init', async (args: InitArgs) => {
   const fn = require(args.script).default

--- a/test/cache-manager.test.ts
+++ b/test/cache-manager.test.ts
@@ -1,6 +1,9 @@
 import Cache from 'hybrid-disk-cache'
 import { initPurgeTimer, stopPurgeTimer } from '../src/cache-manager'
 import { mergeConfig } from '../src/utils'
+import { createLogger } from '../src/logger'
+
+const logger = createLogger()
 
 describe('cache manager', () => {
   it('init and revalidate', done => {
@@ -12,7 +15,7 @@ describe('cache manager', () => {
       stopPurgeTimer()
       return 0
     }
-    initPurgeTimer(cache)
-    initPurgeTimer(cache)
+    initPurgeTimer(cache, logger)
+    initPurgeTimer(cache, logger)
   })
 })

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -3,6 +3,9 @@ import Cache from 'hybrid-disk-cache'
 import request from 'supertest'
 import { gzipSync } from 'zlib'
 import { serveCache } from '../src/utils'
+import { createLogger } from '../src/logger'
+
+const logger = createLogger()
 
 describe('serve cache', () => {
   const cache = new Cache()
@@ -13,7 +16,7 @@ describe('serve cache', () => {
   cache.set('header:' + url, data)
 
   const server = new http.Server(async (req, res) => {
-    const rv = await serveCache(cache, lock, req, res)
+    const rv = await serveCache(cache, lock, req, res, logger)
     expect(rv).toEqual('hit')
   })
 
@@ -31,7 +34,7 @@ describe('serve cache', () => {
 
   it('skip cache when x-cache-status = update', done => {
     const server = new http.Server(async (req, res) => {
-      const status = await serveCache(cache, lock, req, res)
+      const status = await serveCache(cache, lock, req, res, logger)
       expect(status).toEqual('miss')
       res.end('BBB')
     })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,11 @@
-import { filterUrl, isZipped, log, mergeConfig } from '../src/utils'
+import { filterUrl, isZipped, mergeConfig } from '../src/utils'
+import { createLogger } from '../src/logger'
 
 export const sleep = async (t: number) => {
   return new Promise(resolve => setTimeout(resolve, t))
 }
+
+const logger = createLogger()
 
 describe('utils', () => {
   it('is response zipped', () => {
@@ -16,13 +19,13 @@ describe('utils', () => {
 
   it('log with hrtime', async () => {
     const start = process.hrtime()
-    log(start, 'miss', 'A')
+    logger.logOperation(start, 'miss', 'A')
     await sleep(100)
-    log(start, 'hit', 'A')
+    logger.logOperation(start, 'hit', 'A')
     await sleep(1000)
-    log(start, 'hit', 'A')
+    logger.logOperation(start, 'hit', 'A')
     await sleep(1000)
-    log(start, 'hit', 'A')
+    logger.logOperation(start, 'hit', 'A')
   })
 
   it('merge config / no config file', () => {


### PR DESCRIPTION
Hi, and first and foremost thanks a lot for this great library!

The only small issue we've had with this library is that it logs every request and we don't necessarily want to do that on the application level. In order to let people decide if they want to log all the requests or not, I implemented a boolean flag to opt-out from console logs.

This PR adds the possibility of disabling console logs by passing a `debug` boolean flag to `CachedHandler`. It allows disabling console logs only when implementing `next-boost` programmatically. This flag can be easily adapted to the CLI in a different PR. The idea is that the default behavior doesn't change (every request is logged by default), but you have the possibility of disabling logs if you wish so.