### PR TITLE
Fix cache misses with filtered params

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -61,8 +61,8 @@ const SYNC_LOCK = new Set<string>()
 
 const wrap: WrappedHandler = (cache, conf, renderer, plainHandler) => {
   return async (req, res) => {
-    const key = conf.cacheKey ? conf.cacheKey(req) : req.url
     req.url = filterUrl(req.url, conf.paramFilter)
+    const key = conf.cacheKey ? conf.cacheKey(req) : req.url
     const { matched, ttl } = matchRule(conf, req)
     if (!matched) return plainHandler(req, res)
 

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -3,6 +3,9 @@ import { RequestListener } from '../src/renderer'
 
 export default async function init(): Promise<RequestListener> {
   const cb: RequestListener = (req, res) => {
+    if (req.url.startsWith('/params')) {
+      res.write('params')
+    }
     if (req.url === '/hello') {
       res.write('hello')
     } else if (req.url === '/hello-zip') {


### PR DESCRIPTION
Noticed that with paramFilter I was still getting cache misses.
This looks like it was due to the cache key using the full url rather than the filtered url.
Created the cache key after filtering the params from url.