### PR TITLE
Renderer now receives unfiltered url with all params

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -70,6 +70,11 @@ const wrap: WrappedHandler = (cache, conf, renderer, plainHandler) => {
     req.url = filterUrl(req.url, conf.paramFilter)
     const key = conf.cacheKey ? conf.cacheKey(req) : req.url
     const { matched, ttl } = matchRule(conf, req)
+
+    // restore original url so that all params are passed to
+    // the original renderer on cache miss
+    req.url = urlBeforeFilter
+
     if (!matched) return plainHandler(req, res)
 
     const start = process.hrtime()
@@ -79,10 +84,6 @@ const wrap: WrappedHandler = (cache, conf, renderer, plainHandler) => {
     if (stop) return !conf.quiet && log(start, status, req.url)
     // log the time took for staled
     if (status === 'stale') !conf.quiet && log(start, status, req.url)
-
-    // restore original url so that all params are passed to
-    // the original renderer on cache miss
-    req.url = urlBeforeFilter
 
     SYNC_LOCK.add(key)
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -66,6 +66,7 @@ const SYNC_LOCK = new Set<string>()
 
 const wrap: WrappedHandler = (cache, conf, renderer, plainHandler) => {
   return async (req, res) => {
+    const urlBeforeFilter = req.url
     req.url = filterUrl(req.url, conf.paramFilter)
     const key = conf.cacheKey ? conf.cacheKey(req) : req.url
     const { matched, ttl } = matchRule(conf, req)
@@ -78,6 +79,10 @@ const wrap: WrappedHandler = (cache, conf, renderer, plainHandler) => {
     if (stop) return !conf.quiet && log(start, status, req.url)
     // log the time took for staled
     if (status === 'stale') !conf.quiet && log(start, status, req.url)
+
+    // restore original url so that all params are passed to
+    // the original renderer on cache miss
+    req.url = urlBeforeFilter
 
     SYNC_LOCK.add(key)
 


### PR DESCRIPTION
I noticed that `req.url` is directly mutated by the cache handler:

```ts
req.url = filterUrl(req.url, conf.paramFilter)
```

This then strips url params for the original app/next.js renderer and then application does not receive all the query params. 

I think that url filtering should only be done for handler, and no matter what app should (on cache miss) receive original url with all query params.

I noticed this error on our website when redirects stoped working because on redirect app would not receive all the query params from `ctx.query`.

This pull request fixes this with minimal changes. All the tests are passing as well.